### PR TITLE
Add L3, R3 and Capture to Switch report

### DIFF
--- a/XS_HID.c
+++ b/XS_HID.c
@@ -176,7 +176,9 @@ void generate_report_switch(){
   if (buttonStatus[BUTTONSTART]){ReportData.Button |= START_MASK_ON;}
   if (buttonStatus[BUTTONSELECT]){ReportData.Button |= SELECT_MASK_ON;}
   if (buttonStatus[BUTTONHOME]){ReportData.Button |= HOME_MASK_ON;}
-
+  if (buttonStatus[BUTTONL3]){ReportData.Button |= L3_MASK_ON;}
+  if (buttonStatus[BUTTONR3]){ReportData.Button |= R3_MASK_ON;}
+  if (buttonStatus[BUTTONCAPTURE]){ReportData.Button |= CAPTURE_MASK_ON;}
 }
 
 static void generate_report(){

--- a/XS_HID.h
+++ b/XS_HID.h
@@ -36,7 +36,10 @@
 #define ZR_MASK_ON 0x80
 #define START_MASK_ON 0x200
 #define SELECT_MASK_ON 0x100
+#define L3_MASK_ON 0x400
+#define R3_MASK_ON 0x800
 #define HOME_MASK_ON 0x1000
+#define CAPTURE_MASK_ON 0x2000
 
 // XInput digital_buttons_1
 #define XBOX_DPAD_UP    0x01
@@ -79,7 +82,8 @@
 #define BUTTONL3 18
 #define BUTTONR3 19
 #define BUTTONHOME 20
-byte buttonStatus[21];
+#define BUTTONCAPTURE 21
+byte buttonStatus[22];
 
 static bool xs_xinput;
 


### PR DESCRIPTION
I used your code as a base for a project of mine, and I found the Switch reports didn't contain L3, R3 or Capture. This PR adds support for those 3 buttons.

I haven't tested it with your project, but it worked fine in my derived project before I did some refactoring.