### PR TITLE
Adds configurable SOCD cleaning and better default handling

### DIFF
--- a/LUFAHybridFightstick.ino
+++ b/LUFAHybridFightstick.ino
@@ -7,8 +7,12 @@
 #include <inttypes.h>
 
 /* in case you want to disable one type of gamepad */
-//#define DISABLE_NSWITCH 
+//#define DISABLE_NSWITCH
 //#define DISABLE_XINPUT
+
+// Enable on-the-fly SOCD config. If disabled, it'll lock in
+// the default configuration but still use the SOCD resolution code.
+// #define ENABLE_SOCD_CONFIG
 
 //make it so holding start+select triggers the HOME button
 //#define HOME_HOTKEY
@@ -28,6 +32,8 @@
 #define PIN_R     2            //XBOX RB
 #define PIN_ZL    6            //XBOX LT
 #define PIN_ZR    7            //XBOX RT
+#define PIN_LS    17           //XBOX LS
+#define PIN_RS    18           //XBOX RS
 #define PIN_PLUS  16           //XBOX START
 #define PIN_MINUS 10           //XBOX BACK
 #define PIN_HOME  9
@@ -52,6 +58,8 @@ Bounce buttonL = Bounce();
 Bounce buttonR = Bounce();
 Bounce buttonZL = Bounce();
 Bounce buttonZR = Bounce();
+Bounce buttonLS = Bounce();
+Bounce buttonRS = Bounce();
 Bounce buttonPLUS = Bounce();
 Bounce buttonMINUS = Bounce();
 Bounce buttonHOME = Bounce();
@@ -64,32 +72,77 @@ typedef enum {
 } State_t;
 State_t state;
 
+typedef enum {
+  NEUTRAL,    // LEFT/UP + DOWN/RIGHT = NEUTRAL
+  NEGATIVE,   // LEFT/UP beats DOWN/RIGHT
+  POSITIVE,   // DOWN/RIGHT beats LEFT/UP
+  LAST_INPUT, //Last input has priority; not a valid state if being used for initial_input
+} Socd_t;
+Socd_t x_socd_type = NEUTRAL; // controls left/right and up/down resolution type
+Socd_t y_socd_type = NEGATIVE;
+Socd_t x_initial_input, y_initial_input = NEUTRAL;
+
 /* mode selectors */
 bool xinput;
 bool modeChanged;
 
 void checkModeChange(){
-    if (buttonStatus[BUTTONSTART] && buttonStatus[BUTTONSELECT])
+  if (buttonStatus[BUTTONSTART] && buttonStatus[BUTTONSELECT])
+  {
+    if ( !modeChanged )
     {
-      if ( !modeChanged )
-      {
-        bool need_update = true;
-        if (internalButtonStatus[BUTTONLEFT])
-          state = ANALOG_MODE;
-        else if (internalButtonStatus[BUTTONRIGHT])
-          state = RIGHT_ANALOG_MODE;
-        else if (internalButtonStatus[BUTTONUP])
-          state = DIGITAL;
-        else need_update = false;
+      bool need_update = true;
+      if (internalButtonStatus[BUTTONLEFT])
+        state = ANALOG_MODE;
+      else if (internalButtonStatus[BUTTONRIGHT])
+        state = RIGHT_ANALOG_MODE;
+      else if (internalButtonStatus[BUTTONUP])
+        state = DIGITAL;
+      else need_update = false;
         
         if (need_update) EEPROM.put(0, state);
-        modeChanged = true;
-      }
+      modeChanged = true;
     }
-    else 
+  }
+#ifdef ENABLE_SOCD_CONFIG
+  else if (buttonStatus[BUTTONL3] && buttonStatus[BUTTONR3])
+  {
+    if (!modeChanged)
     {
-      modeChanged = false;
+      // read inputs at time of press
+      bool up = !joystickUP.read();
+      bool down = !joystickDOWN.read();
+      bool left = !joystickLEFT.read();
+      bool right = !joystickRIGHT.read();
+
+      if (up && down)
+        y_socd_type = LAST_INPUT;
+      else if (up)
+        y_socd_type = NEGATIVE;
+      else if (down)
+        y_socd_type = POSITIVE;
+      else if (!up && !down)
+        y_socd_type = NEUTRAL;
+
+      if (left && right)
+        x_socd_type = LAST_INPUT;
+      else if (left)
+        x_socd_type = NEGATIVE;
+      else if (right)
+        x_socd_type = POSITIVE;
+      else if (!left && !right)
+        x_socd_type = NEUTRAL;
+
+      EEPROM.put(4, x_socd_type);
+      EEPROM.put(6, y_socd_type);
+      modeChanged = true;
     }
+  }
+#endif
+  else
+  {
+    modeChanged = false;
+  }
 }
 
 void setupPins(){
@@ -105,9 +158,11 @@ void setupPins(){
     buttonR.attach(PIN_R,INPUT_PULLUP);      // XBOX RB
     buttonZL.attach(PIN_ZL,INPUT_PULLUP);     // XBOX LT
     buttonZR.attach(PIN_ZR,INPUT_PULLUP);     // XBOX RT
-    buttonPLUS.attach(PIN_PLUS,INPUT_PULLUP);  // XBOX START
-    buttonMINUS.attach(PIN_MINUS,INPUT_PULLUP); // XBOX BACK
-    buttonHOME.attach(PIN_HOME,INPUT_PULLUP);
+    buttonLS.attach(PIN_LS, INPUT_PULLUP);       // XBOX LS
+    buttonRS.attach(PIN_RS, INPUT_PULLUP);       // XBOX RS
+    buttonPLUS.attach(PIN_PLUS, INPUT_PULLUP);   // XBOX START
+    buttonMINUS.attach(PIN_MINUS, INPUT_PULLUP); // XBOX BACK
+    buttonHOME.attach(PIN_HOME, INPUT_PULLUP);
 
     joystickUP.interval(MILLIDEBOUNCE);
     joystickDOWN.interval(MILLIDEBOUNCE);
@@ -121,15 +176,21 @@ void setupPins(){
     buttonR.interval(MILLIDEBOUNCE);
     buttonZL.interval(MILLIDEBOUNCE);
     buttonZR.interval(MILLIDEBOUNCE);
+    buttonLS.interval(MILLIDEBOUNCE);
+    buttonRS.interval(MILLIDEBOUNCE);
     buttonPLUS.interval(MILLIDEBOUNCE);
     buttonMINUS.interval(MILLIDEBOUNCE);
     buttonHOME.interval(MILLIDEBOUNCE);
 }
 void setup() {
-
+  
   modeChanged = false;
   EEPROM.get(0, state);
   EEPROM.get(2, xinput);
+#ifdef ENABLE_SOCD_CONFIG
+  EEPROM.get(4, x_socd_type);
+  EEPROM.get(6, y_socd_type);
+#endif
   setupPins();
   delay(500);
 
@@ -151,17 +212,17 @@ void setup() {
     xinput = false;
     EEPROM.put(2, xinput);
   }
-// if start is held on boot, XInput mode
+  // if start is held on boot, XInput mode
   else {
     value = digitalRead(PIN_PLUS);
     if (value == LOW)
-      {
-        xinput = true;
-        EEPROM.put(2, xinput);
-      }
+    {
+      xinput = true;
+      EEPROM.put(2, xinput);
+    }
   }
 #endif
-#endif  
+#endif
   SetupHardware(xinput);
   GlobalInterruptEnable();
 }
@@ -170,13 +231,16 @@ void setup() {
 void loop() {
     currTime = millis();
     buttonRead();
-    checkModeChange();    
+    checkModeChange();
     convert_dpad();
     send_pad_state();
 }
 
 void convert_dpad(){
-  
+  // Prevent SOCD inputs (left+right or up+down) from making it to the logic below.
+  clean_socd(&internalButtonStatus[BUTTONLEFT], &internalButtonStatus[BUTTONRIGHT], &x_socd_type, &x_initial_input);
+  clean_socd(&internalButtonStatus[BUTTONUP], &internalButtonStatus[BUTTONDOWN], &y_socd_type, &y_initial_input);
+
   switch (state)
   {
     case DIGITAL:
@@ -189,15 +253,15 @@ void convert_dpad(){
     buttonStatus[BUTTONLEFT] = internalButtonStatus[BUTTONLEFT];
     buttonStatus[BUTTONRIGHT] = internalButtonStatus[BUTTONRIGHT];
     break;
-    
-    case RIGHT_ANALOG_MODE:   
+
+    case RIGHT_ANALOG_MODE:
     buttonStatus[AXISLX] = 128;
     buttonStatus[AXISLY] = 128;
     buttonStatus[BUTTONUP] = 0;
     buttonStatus[BUTTONDOWN] = 0;
     buttonStatus[BUTTONLEFT] = 0;
     buttonStatus[BUTTONRIGHT] = 0;
-    
+
     if ((internalButtonStatus[BUTTONUP]) && (internalButtonStatus[BUTTONRIGHT])){buttonStatus[AXISRY] = 0;buttonStatus[AXISRX] = 255;}
     else if ((internalButtonStatus[BUTTONUP]) && (internalButtonStatus[BUTTONLEFT])){buttonStatus[AXISRY] = 0;buttonStatus[AXISRX] = 0;}
     else if ((internalButtonStatus[BUTTONDOWN]) && (internalButtonStatus[BUTTONRIGHT])) {buttonStatus[AXISRY] = 255;buttonStatus[AXISRX] = 255;}
@@ -209,17 +273,17 @@ void convert_dpad(){
     else {buttonStatus[AXISRX] = 128;buttonStatus[AXISRY] = 128;}
 
     break;
-    
+
     case ANALOG_MODE:
       /* fallthrough */
-    default:  
+    default:
     buttonStatus[AXISRX] = 128;
     buttonStatus[AXISRY] = 128;
     buttonStatus[BUTTONUP] = 0;
     buttonStatus[BUTTONDOWN] = 0;
     buttonStatus[BUTTONLEFT] = 0;
     buttonStatus[BUTTONRIGHT] = 0;
-    
+
     if ((internalButtonStatus[BUTTONUP]) && (internalButtonStatus[BUTTONRIGHT])){buttonStatus[AXISLY] = 0;buttonStatus[AXISLX] = 255;}
     else if ((internalButtonStatus[BUTTONDOWN]) && (internalButtonStatus[BUTTONRIGHT])) {buttonStatus[AXISLY] = 255;buttonStatus[AXISLX] = 255;}
     else if ((internalButtonStatus[BUTTONDOWN]) && (internalButtonStatus[BUTTONLEFT])) {buttonStatus[AXISLY] = 255;buttonStatus[AXISLX] = 0;}
@@ -231,17 +295,23 @@ void convert_dpad(){
     else {buttonStatus[AXISLX] = 128;buttonStatus[AXISLY] = 128;}
 
     break;
-    
-    
+
+
   }
 }
 
 void buttonRead()
-{  
-  if (joystickUP.update()) {internalButtonStatus[BUTTONUP] = joystickUP.fell();}
-  if (joystickDOWN.update()) {internalButtonStatus[BUTTONDOWN] = joystickDOWN.fell();}
-  if (joystickLEFT.update()) {internalButtonStatus[BUTTONLEFT] = joystickLEFT.fell();}
-  if (joystickRIGHT.update()) {internalButtonStatus[BUTTONRIGHT] = joystickRIGHT.fell();}
+{
+  // for SOCD cleaning to work properly we need directions to update
+  // on any change instead of on fall
+  joystickUP.update(); joystickDOWN.update(); joystickLEFT.update(); joystickRIGHT.update();
+  if (joystickUP.changed() || joystickDOWN.changed() || joystickLEFT.changed() || joystickRIGHT.changed())
+  {
+    internalButtonStatus[BUTTONUP] = !joystickUP.read();
+    internalButtonStatus[BUTTONDOWN] = !joystickDOWN.read();
+    internalButtonStatus[BUTTONLEFT] = !joystickLEFT.read();
+    internalButtonStatus[BUTTONRIGHT] = !joystickRIGHT.read();
+  }
   if (buttonA.update()) {buttonStatus[BUTTONA] = buttonA.fell();}
   if (buttonB.update()) {buttonStatus[BUTTONB] = buttonB.fell();}
   if (buttonX.update()) {buttonStatus[BUTTONX] = buttonX.fell();}
@@ -254,18 +324,77 @@ void buttonRead()
   if (buttonMINUS.update()) {buttonStatus[BUTTONSELECT] = buttonMINUS.fell();}
   if (buttonHOME.update()) { buttonStatus[BUTTONHOME] = buttonHOME.fell();}
 
-#ifdef HOME_HOTKEY  
+#ifdef HOME_HOTKEY
   if(buttonStatus[BUTTONSTART] && buttonStatus[BUTTONSELECT]) {
-   if (startAndSelTime == 0)
-    startAndSelTime = millis();
-   else if (currTime - startAndSelTime > HOME_DELAY)
-   {
+    if (startAndSelTime == 0)
+      startAndSelTime = millis();
+    else if (currTime - startAndSelTime > HOME_DELAY)
+    {
       buttonStatus[BUTTONHOME] = 1;
-   }
+    }
  } else {
-  startAndSelTime = 0;
-  buttonStatus[BUTTONHOME] = 0;
- }
+    startAndSelTime = 0;
+    buttonStatus[BUTTONHOME] = 0;
+  }
 #endif
-  
+}
+
+/**
+ * Cleans the given (possible) simultaneous opposite cardinal direction inputs according to the preferences provided.
+ * 
+ * @note Given two simultaneous opposite cardinal direction inputs, clean_socd will
+ * make sure that both are not actually sent. The method used to resolve this conflict
+ * is determined by input_priority. The x (LEFT/RIGHT) and y (UP/DOWN) axes can be
+ * handled with the same logic as long as the negative and positive inputs are correctly
+ * arranged, so pointers are used to make the same function handle both.
+ * 
+ * @param[in,out] negative The LEFT/UP input variable. 
+ * @param[in,out] positive  The DOWN/RIGHT input variable.
+ * @param[in] input_priority Determines the SOCD resolution method used. @see Socd_t for how each resolution method works.
+ * @param[in,out] initial_input If input_priority = LAST_INPUT and SOCD cleaning is needed, this is used to determine 
+ *  which input was made last. If only one input is made, this variable is set to that input, even if input_priority != LAST_INPUT.
+ */
+void clean_socd(byte *negative, byte *positive, Socd_t *input_priority, Socd_t *initial_input)
+{
+  if (*negative && *positive) // SOCD that needs to be resolved
+  {
+    switch (*input_priority)
+    {
+    case NEUTRAL:
+      *negative = *positive = false;
+      break;
+    case NEGATIVE:
+      *negative = true;
+      *positive = false;
+      break;
+    case POSITIVE:
+      *negative = false;
+      *positive = true;
+      break;
+    case LAST_INPUT:
+      // Check which input was made first to figure out which input was made last, which wins.
+      switch (*initial_input)
+      {
+      case NEGATIVE:
+        *negative = false;
+        *positive = true;
+        break;
+      case POSITIVE:
+        *negative = true;
+        *positive = false;
+        break;
+      // This is a fallback case for when there hasn't been an input since starting up.
+      case NEUTRAL:
+        *negative = *positive = false;
+        break;
+      }
+    }
+  }
+  else // no SOCD to resolve, which means our current input (if any) should be set as the initial input.
+  {
+    if (*negative && !*positive)
+      *initial_input = NEGATIVE;
+    if (*positive && !*negative)
+      *initial_input = POSITIVE;
+  }
 }

--- a/LUFAHybridFightstick.ino
+++ b/LUFAHybridFightstick.ino
@@ -319,7 +319,10 @@ void buttonRead()
   if (buttonL.update()) {buttonStatus[BUTTONLB] = buttonL.fell();}
   if (buttonR.update()) {buttonStatus[BUTTONRB] = buttonR.fell();}
   if (buttonZL.update()) {buttonStatus[BUTTONLT] = buttonZL.fell();}
-  if (buttonZR.update()) {buttonStatus[BUTTONRT] = buttonZR.fell();}
+  if (buttonZR.update()) {buttonStatus[BUTTONRT] = buttonZR.fell();} 
+  //not a typo, XS_HID wants L3/R3 instead of LS/RS
+  if (buttonLS.update()) {buttonStatus[BUTTONL3] = buttonLS.fell();}
+  if (buttonRS.update()) {buttonStatus[BUTTONR3] = buttonRS.fell(); }
   if (buttonPLUS.update()) {buttonStatus[BUTTONSTART] = buttonPLUS.fell();}
   if (buttonMINUS.update()) {buttonStatus[BUTTONSELECT] = buttonMINUS.fell();}
   if (buttonHOME.update()) { buttonStatus[BUTTONHOME] = buttonHOME.fell();}

--- a/README.md
+++ b/README.md
@@ -35,6 +35,30 @@ DPAD mode is also persistent.
 
 Because the neogeo pad 2 doesn't have a home button, I also added some code so that holding start+select during more than 1 second presses the home button. You can customize the delay with #define HOME_DELAY 1000 in the .ino file.
 
+### SOCD Cleaning
+
+When simultaneous opposite cardinal direction (SOCD) inputs are detected, the default 
+resolution follows the standard hitbox-style setup: LEFT + RIGHT = NEUTRAL and UP + DOWN = UP.
+
+SOCD configuration can be enabled with `ENABLE_SOCD_CONFIG`. This allows the x (LEFT/RIGHT) and
+y (UP/DOWN) axes to each have their own SOCD mode. These options are stored in persistent memory.
+
+Changes are performed by holding down input directions corresponding to your desired setup and 
+then pressing the SOCD configuration button combination, which is set to L3+R3 by default.
+
+- If no buttons are held down, simultaneous inputs output neutral. This is the default L+R behavior for hitbox-style controllers.
+- If one button is held down, that button will take priority when simultaneous inputs are made. This is the default U+D behavior for hitbox-style controllers — when both are held down, UP always has priority.
+- If both buttons are held down, the last input will take priority. (Also known as second input priority.)
+
+For example, to set the SOCD configuration to the default hitbox-style setup:
+- Release all directional inputs, hold UP, and press the SOCD configuration button combination.
+
+To make all SOCDs resolve to neutral:
+- Release all directional inputs and press the config button.
+
+To enable last input priority on both axes:
+- Press and hold all directional inputs, and then press the config button.
+
 ## Building Instructions
 
 - Download Arduino IDE, 


### PR DESCRIPTION
Currently, if an SOCD input is made, convert_dpad() isn't terribly happy about that. Since I use a hitbox-style DIY controller, I added handling for both the default case and (if the define is enabled) on-the-fly configuration. Stick players shouldn't see any changes, since joysticks can't make SOCD inputs. 

I've been using this particular implementation for a while, and it seems to work okay — I can't perceive any additional input lag, although that comparison is made using amateur feel and not usblag. I've also tested it with Switch mode on my PC, and the output appears to be fine, but I don't have a Switch to perform further testing on.

I did my best to retain existing formatting, but vscode appears to be less picky with judging equivalent whitespace than github's online interface is and apologize for any mess.